### PR TITLE
SEC: Update 'rake' and 'puma' gems to address CVE-2020-8130 and CVE-2020-5247 respectively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # README: http://makefiletutorial.com
 TARGET_PATH   = /src/app
 VOLUME_PATH   = $(shell pwd):$(TARGET_PATH)
-RUBY_IMAGE    = krates/toolbox:2.4.9-5
+RUBY_IMAGE    = krates/toolbox:2.4.9-7
 DOCKER_SOCKET = /var/run/docker.sock:/var/run/docker.sock
 
 # Courtesy of: https://stackoverflow.com/a/49524393/3072002

--- a/agent/Gemfile.lock
+++ b/agent/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (2.0.5)
-    rake (12.0.0)
+    rake (13.0.1)
     rbtrace (0.4.8)
       ffi (>= 1.0.6)
       msgpack (>= 0.4.3)

--- a/cli/krates.gemspec
+++ b/cli/krates.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   # TODO: Restore metadata section back
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_runtime_dependency "excon", "0.62.0"
   spec.add_runtime_dependency "tty-prompt", "0.16.1"
   spec.add_runtime_dependency "clamp", "~> 1.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.6"
 services:
   # NOTE: This is a development box service
   toolbox:
-    image: krates/toolbox:2.4.9-5
+    image: krates/toolbox:2.4.9-7
     working_dir: /src/app
     logging:
       driver: "journald"

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (4.0.3)
-    puma (4.3.1)
+    puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.0.8)
     rack-attack (6.2.2)


### PR DESCRIPTION
…020-5247 respectively