### PR TITLE
Support for automatic upgrades of Server and Agent components 

### DIFF
--- a/agent/lib/kontena/rpc/agent_api.rb
+++ b/agent/lib/kontena/rpc/agent_api.rb
@@ -5,29 +5,10 @@ module Kontena
     class AgentApi
 
       # @param [Hash] data
-      def master_info(data)
-        Celluloid::Notifications.publish('websocket:connected', {master: data})
-        update_version(data['version']) if data['version']
-        {}
-      end
-
-      # @param [Hash] data
       def node_info(data)
         node = Node.new(data)
         Celluloid::Notifications.publish('agent:node_info', node)
         {}
-      end
-
-      private
-
-      # @param [String] version
-      def update_version(version)
-        env_file = '/etc/kontena.env'
-        if File.exist?(env_file)
-          env = File.read(env_file)
-          env.gsub!(/^KONTENA_VERSION=.+$/, "KONTENA_VERSION=#{version}")
-          File.write(env_file, env)
-        end
       end
     end
   end

--- a/agent/spec/lib/kontena/rpc/agent_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/agent_api_spec.rb
@@ -4,15 +4,6 @@ describe Kontena::Rpc::AgentApi do
   before(:each) { Celluloid.boot }
   after(:each) { Celluloid.shutdown }
 
-  describe '#master_info' do
-    it 'publishes event' do
-      info = {'version' => '0.10.0'}
-      expect(Celluloid::Notifications).to receive(:publish).with('websocket:connected', {master: info})
-      subject.master_info(info)
-      sleep 0.01
-    end
-  end
-
   describe '#node_info' do
     it 'publishes event' do
       info = {'id' => 'xyz'}


### PR DESCRIPTION
Here is the list of changes:
 - **WebsocketBackend:** `Server` requires exact version match from `Agent` to be connected;
 - **AgentApi:** Discontinue `master_info` since auto-update relies on `always latest` approach