### PR TITLE
Support for automatic upgrades of Server and Agent components

### DIFF
--- a/agent/lib/kontena/rpc/agent_api.rb
+++ b/agent/lib/kontena/rpc/agent_api.rb
@@ -7,7 +7,6 @@ module Kontena
       # @param [Hash] data
       def master_info(data)
         Celluloid::Notifications.publish('websocket:connected', {master: data})
-        update_version(data['version']) if data['version']
         {}
       end
 
@@ -16,18 +15,6 @@ module Kontena
         node = Node.new(data)
         Celluloid::Notifications.publish('agent:node_info', node)
         {}
-      end
-
-      private
-
-      # @param [String] version
-      def update_version(version)
-        env_file = '/etc/kontena.env'
-        if File.exist?(env_file)
-          env = File.read(env_file)
-          env.gsub!(/^KONTENA_VERSION=.+$/, "KONTENA_VERSION=#{version}")
-          File.write(env_file, env)
-        end
       end
     end
   end

--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -11,6 +11,7 @@ module Kontena::Workers
       @container = container
       @queue = queue
       @dropped = 0
+      info 'initialized'
       every(60) {
         if @dropped > 0
           warn "dropped #{@dropped} log lines because queue was full"

--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -80,11 +80,7 @@ module Kontena::Workers
     # Start streaming and processing after etcd is running
     def start
       info 'starting worker'
-      wait_until!("etcd running") {
-        up = Actor[:etcd_launcher].running?
-        info "waiting for etcd actor to be running ~> #{up}"
-        return up
-      }
+      wait_until!("etcd running") { Actor[:etcd_launcher].running? }
 
       exclusive {
         start_streaming unless streaming?

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -353,7 +353,9 @@ class WebsocketBackend
   # @param [String] agent_version
   # @return [Boolean]
   def valid_agent_version?(agent_version)
-    Gem::Dependency.new('', "~> #{self.our_version}").match?('', agent_version)
+    match = Gem::Dependency.new('', "~> #{Server::VERSION}").match?('', agent_version)
+    logger.info "Matching server's version '#{Server::VERSION}' to worker's '#{agent_version}' and match is '#{match}'"
+    return match
   end
 
   # @return [String]

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -8,6 +8,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
   before do
     allow(subject).to receive(:logger).and_return(logger)
     allow(logger).to receive(:debug)
+    allow(logger).to receive(:info)
   end
 
   before(:each) do
@@ -34,8 +35,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       expect(subject.valid_agent_version?('0.9.2')).to eq(true)
     end
 
-    it 'returns true when patch level is less than' do
-      expect(subject.valid_agent_version?('0.9.0')).to eq(true)
+    it 'returns false when patch level is less than' do
+      expect(subject.valid_agent_version?('0.9.0')).to eq(false)
     end
 
     it 'returns false when minor version is different' do


### PR DESCRIPTION
Here is the list of changes:
 - **WebsocketBackend:** `Server` requires exact version match from `Agent` to be connected;
 - **AgentApi:** Discontinue `master_info` since auto-update relies on `always latest` approach