### PR TITLE
Support for 'KRATES_MASTER_IDENTITY_FILE' and 'KRATES_NODE_IDENTITY_FILE' environment variables

### DIFF
--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Master
 
     parameter "[COMMANDS] ...", "Run command on host"
 
-    option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
+    option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key", environment_variable: 'KRATES_MASTER_IDENTITY_FILE'
     option ["-u", "--user"], "USER", "Login as a user", default: "core"
 
     requires_current_master

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Nodes
     parameter "[NODE]", "SSH to Grid node. Use --any to connect to the first available node"
     parameter "[COMMANDS] ...", "Run command on host"
     option ["-a", "--any"], :flag, "Connect to first available node"
-    option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
+    option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key", environment_variable: 'KRATES_NODE_IDENTITY_FILE'
     option ["-u", "--user"], "USER", "Login as a user", default: "core"
     option "--private-ip", :flag, "Connect to node's private IP address"
     option "--internal-ip", :flag, "Connect to node's internal IP address (requires VPN connection)"

--- a/cli/spec/kontena/cli/master/ssh_command_spec.rb
+++ b/cli/spec/kontena/cli/master/ssh_command_spec.rb
@@ -1,0 +1,24 @@
+require 'kontena/cli/master/ssh_command'
+
+describe Kontena::Cli::Master::SshCommand do
+  include ClientHelpers
+
+  let(:master_host) { 'master.krates.io' }
+  let(:identity_file) { '~/x/y/z/id_rsa' }
+
+  before do
+    allow(client).to receive(:get).with('v1/config/server.provider').and_return({})
+    allow(subject).to receive(:master_host).and_return(master_host)
+    # NOTE: This stub should be factored out into its own context in case of Vagrant spec support
+    allow(subject).to receive(:master_is_vagrant?).and_return(false)
+  end
+
+  it "uses environment variable to provide identity file to SSH" do
+    # Stub
+    allow(ENV).to receive(:key?).and_return(true)
+    allow(ENV).to receive(:[]).with('KRATES_MASTER_IDENTITY_FILE').and_return(identity_file)
+    # Assert
+    expect(subject).to receive(:exec).with('ssh', "core@#{master_host}", '-i', identity_file)
+    subject.run []
+  end
+end

--- a/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
@@ -60,4 +60,13 @@ describe Kontena::Cli::Nodes::SshCommand do
     expect(subject).to receive(:exec).with('ssh', 'core@192.0.2.10', '-F', 'ssh/config' 'ls', '-l')
     subject.run ['test-node', '--', '-F', 'ssh/config' 'ls', '-l']
   end
+
+  it "uses environment variable to provide identity file to SSH" do
+    # Stub ENV keys access to mimic correct state of the variable(s)
+    allow(ENV).to receive(:key?).and_return(true)
+    allow(ENV).to receive(:[]).with('KRATES_NODE_IDENTITY_FILE').and_return('~/x/y/z/id_rsa')
+    # Assert use case
+    expect(subject).to receive(:exec).with('ssh', '-i', '~/x/y/z/id_rsa', 'core@192.0.2.10')
+    subject.run ['test-node']
+  end
 end


### PR DESCRIPTION
- CLI: Support for `KRATES_NODE_IDENTITY_FILE` environment variable to read identity file from in `node ssh` command;
- CLI: Support for `KRATES_MASTER_IDENTITY_FILE` environment variable to read identity file from in `master ssh` command;