### PR TITLE
CLI: Support for '--internal-ip' in 'node ssh' command to allow connect to a remote Vagrant node via overlay ip

### DIFF
--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -33,7 +33,7 @@ module Kontena::Cli::Nodes
 
       provider = Array(node["labels"]).find{ |l| l.start_with?('provider=')}.to_s.split('=').last
 
-      if provider == 'vagrant'
+      if provider == 'vagrant' && !internal_ip?
         unless Kontena::PluginManager::Common.installed?('vagrant')
           exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'
         end

--- a/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
@@ -12,8 +12,16 @@ describe Kontena::Cli::Nodes::SshCommand do
     }
   end
 
+  let :vagrant_node do
+    {
+      'labels' => ['provider=vagrant'],
+      'overlay_ip' => '10.81.0.2',
+    }
+  end
+
   before do
     allow(client).to receive(:get).with('nodes/test-grid/test-node').and_return(node)
+    allow(client).to receive(:get).with('nodes/test-grid/vagrant-node').and_return(vagrant_node)
   end
 
   describe '--any flag' do
@@ -49,6 +57,11 @@ describe Kontena::Cli::Nodes::SshCommand do
   it "uses the overlay IP" do
     expect(subject).to receive(:exec).with('ssh', 'core@10.81.0.1')
     subject.run ['--internal-ip', 'test-node']
+  end
+
+  it "uses the overlay IP for vagrant node" do
+    expect(subject).to receive(:exec).with('ssh', 'core@10.81.0.2')
+    subject.run ['--internal-ip', 'vagrant-node']
   end
 
   it "passes through the command to SSH" do


### PR DESCRIPTION
**ISSUE**
Right now, for any Vagrant-powered vm we cannot connect to it via `node ssh ...` since the code always falls back to local `vagrant ssh ...` case for any `vagrant-powered` node(s) `provider=vagrant` and it is impossible to connect to a Vagrant node via VPN using `node ssh ...` command.

**HOW IT SHOULD BE**
`node ssh --internal-ip ...` command should recognize the case of a remote Vagrant-powered vm and actually use `ssh -i ...` command instead therefore making it possible to connect remotely to these nodes.